### PR TITLE
Travis CI: Do the flake8 tests but not update_all.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ install:
     - pip install unicode unidecode lxml
 before_script:
     # stop the build if there are Python syntax errors or undefined names
-    #- flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-    #- flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-script:
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script: true  # disable for now while we figure out how to pass secrets. See #2
     #- pytest --capture=sys  # add other tests here
-    - cd example/cz_app
-    - python ../../scripts/update_all.py -c common.cfg -c private.cfg
+    #- cd example/cz_app
+    #- python ../../scripts/update_all.py -c common.cfg -c private.cfg
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Disable __update_all.py__ in Travis CI for now while we figure out [how to pass secrets](https://docs.travis-ci.com/user/encryption-keys). See #2