### PR TITLE
Travis CI: Add flake8 tests to find undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,31 @@ group: travis_latest
 language: python
 cache: pip
 python:
-- 2.7
-- 3.6
+  - 2.7
+  - 3.6
 matrix:
   allow_failures:
     - python: 3.6
 
 install:
-- pip install flake8 pytest
-- pip install -r requirements.txt
+  - pip install flake8 pytest
+  - pip install -r requirements.txt
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
-- ./ci/travis.sh
+  - ./ci/travis.sh
 
 notifications:
   email:
     recipients:
-#    - tondrej@cz.ibm.com
-#    - tomas_macek@cz.ibm.com
-    - tereza.pytelova@cz.ibm.com
+      #- tondrej@cz.ibm.com
+      #- tomas_macek@cz.ibm.com
+      - tereza.pytelova@cz.ibm.com
     on_success: change
     on_failure: always
     on_pull_requests: false


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree