### PR TITLE
Modernize Python 2 code to get ready for Python 3 without absolute_import

### DIFF
--- a/scripts/IntentData.py
+++ b/scripts/IntentData.py
@@ -129,7 +129,7 @@ class IntentData(object):
 
         if isinstance(channel, str):
             channel = channel.decode('utf-8')
-        if unicode.isdigit(channel[0]):
+        if channel[0].isdigit():
             channelName = channel[0]
             channelValue = channel[1:]
         self.addChannelOutput(channelName, channelValue)

--- a/scripts/XLSXHandler.py
+++ b/scripts/XLSXHandler.py
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
 import os, re
 import unidecode
 from openpyxl import load_workbook
@@ -67,18 +66,25 @@ class XLSXHandler(object):
         if not os.path.exists(filename):
             eprintf('Error: File does not exist: %s\n', filename)
             return {}
-    
+
         try:
-            domainName = unicode(toIntentName(NAME_POLICY, None, os.path.splitext(os.path.split(filename)[1])[0]), 'utf-8')
+            domainName = toIntentName(NAME_POLICY, None, os.path.splitext(os.path.split(filename)[1])[0])
+            try:
+                domainName = unicode(domainName, 'utf-8')  # Python 2
+            except NameError:
+                domainName = str(domainName)               # Python 3
             workbook = load_workbook(filename=filename, read_only=True)
         except (IOError, BadZipfile):
             eprintf('Error: File does not seem to be a valid Excel spreadsheet: %s\n', filename)
             return {}
-    
+
         # Process all the tabs of the file
         for sheet in workbook.worksheets:
             printf(' Sheet: %s\n', sheet.title)
-            prefix = unicode(sheet.title, 'utf-8')
+            try:
+                prefix = unicode(sheet.title, 'utf-8')  # Python 2
+            except NameError:
+                prefix = str(sheet.title)               # Python 3
             currentBlock = []
 
             # Separate all data blocks in the sheet, if the currentBlock starts with header, it is considered to be part of currentBlock
@@ -216,4 +222,3 @@ class XLSXHandler(object):
                 intentData.addIntentAlternative(row[0])  # Collect intent definition
             if row[1]:
                 intentData.addRawOutput(row[1:], self._labelsMap)  # Collect text output
-

--- a/scripts/cfgCommons.py
+++ b/scripts/cfgCommons.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import logging, configparser, sys
 from wawCommons import printf, eprintf

--- a/scripts/clean_generated.py
+++ b/scripts/clean_generated.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import sys, argparse, os
 import wawCommons

--- a/scripts/dialog_json2xml.py
+++ b/scripts/dialog_json2xml.py
@@ -12,10 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import json, sys, argparse, os
 import lxml.etree as LET
 from wawCommons import printf, eprintf
+
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
+
 
 def convertDialog(dialogNodesJSON):
     dialogXML = LET.Element("nodes")

--- a/scripts/dialog_xls2xml.py
+++ b/scripts/dialog_xls2xml.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 # coding: utf-8
 import sys, argparse, os, codecs

--- a/scripts/dialog_xml2json.py
+++ b/scripts/dialog_xml2json.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import json,sys,argparse,os,re,csv,io,copy
 import lxml.etree as LET
@@ -20,6 +21,11 @@ from cfgCommons import Cfg
 from wawCommons import printf, eprintf
 import time
 import datetime
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 # CONSTANTS (care it is not real constant)
 DEFAULT_SELECTOR = 'user_input'
@@ -816,7 +822,7 @@ if __name__ == '__main__':
             outputFile.write(json.dumps(dialogNodes, indent=4))
         printf("File %s created\n", os.path.join(getattr(config, 'common_outputs_directory'), getattr(config, 'common_outputs_dialogs')))
     else:
-        print json.dumps(dialogNodes, indent=4)
+        print(json.dumps(dialogNodes, indent=4))
 
     if hasattr(config, 'common_output_config'):
         config.saveConfiguration(getattr(config, 'common_output_config'))

--- a/scripts/entities_csv2json.py
+++ b/scripts/entities_csv2json.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import json,sys,argparse,os
 
@@ -117,7 +118,7 @@ if __name__ == '__main__':
             outputFile.write(json.dumps(entitiesJSON, indent=4).encode('utf8'))
         if VERBOSE: printf("Entities json '%s' was successfully created\n", os.path.join(getattr(config, 'common_outputs_directory'), getattr(config, 'common_outputs_entities')))
     else:
-        print json.dumps(entitiesJSON, indent=4, ensure_ascii=False).encode('utf8')
+        print(json.dumps(entitiesJSON, indent=4, ensure_ascii=False).encode('utf8'))
         if VERBOSE: printf("Entities json was successfully created\n", os.path.basename(__file__))
 
     printf('\nFINISHING: ' + os.path.basename(__file__) + '\n')

--- a/scripts/evaluate_tests.py
+++ b/scripts/evaluate_tests.py
@@ -17,6 +17,11 @@ import json, sys, argparse, requests, os, time, datetime, re
 import lxml.etree as LET
 from wawCommons import printf, eprintf
 
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
+
 
 def areSame(expectedOutputJson, receivedOutputJson, failureData, parentPath):
 
@@ -161,9 +166,13 @@ if __name__ == '__main__':
 
             line = 0
             dialogId = 0
+            nTestsinDialog = 0
+            nFailuresInDialog = 0
+            timeDialogStart = time.time()
+
             # for every line
             while expectedJsonLine:
-                line += 1;
+                line += 1
                 if not receivedJsonLine: # no more received line
                     eprintf('ERROR: Missing output JSON in file %s, line %d', args.receivedFileName, line)
                     sys.exit(1)
@@ -233,7 +242,7 @@ if __name__ == '__main__':
 
             # end for each line
 
-            if receivedJsonLine: eprintf('ERROR: More than expected lines in file %s, line %d', receivedFileName, line)
+            if receivedJsonLine: eprintf('ERROR: More than expected lines in file %s, line %d', args.receivedFileName, line)
 
         # close files
 

--- a/scripts/intents_csv2json.py
+++ b/scripts/intents_csv2json.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import json, sys, argparse, os, glob, codecs
 from wawCommons import printf, eprintf, getFilesAtPath, toIntentName

--- a/scripts/update_all.py
+++ b/scripts/update_all.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import os, sys, logging
 import subprocess, argparse
@@ -37,7 +38,7 @@ if __name__ == '__main__':
             if os.path.isfile(strParamsItem):
                 paramsAll+= ' -c '+strParamsItem
             else:
-                print('ERROR: Configuration file %s not found.', strParamsItem)
+                print(('ERROR: Configuration file %s not found.', strParamsItem))
                 exit(1)
     else:
         # create list of default config files
@@ -45,9 +46,9 @@ if __name__ == '__main__':
             if os.path.isfile(strParamsItem):
                 paramsAll += ' -c ' + strParamsItem
             else:
-                print('WARNING: Default configuration file %s was not found, ignoring.', strParamsItem)
+                print(('WARNING: Default configuration file %s was not found, ignoring.', strParamsItem))
     if len(paramsAll)==0:
-        print('ERROR: Please provide at least one configuration file.', strParamsItem)
+        print(('ERROR: Please provide at least one configuration file.', strParamsItem))
         exit(1)
     if VERBOSE:
         paramsAll+=' -v'

--- a/scripts/wawCommons.py
+++ b/scripts/wawCommons.py
@@ -93,7 +93,7 @@ def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
                     if replacementPair[1] == '\L':
                         uNewIntentSubnameUser = uIntentSubnameUser.lower()
                         triggeredUserRegexToAppend = "intent name should be lowercase"
-                    elif replacementPair[1] == '\U':
+                    elif replacementPair[1] == r'\U':
                         uNewIntentSubnameUser = uIntentSubnameUser.upper()
                         triggeredUserRegexToAppend = "intent name should be uppercase"
                     elif replacementPair[1] == '\A':
@@ -157,7 +157,7 @@ def toEntityName(NAME_POLICY, userReplacements, entityName):
                 if replacementPair[1] == '\L':
                     uNewEntityNameUser = uEntityNameUser.lower()
                     triggeredUserRegexToAppend = "entity name should be lowercase"
-                elif replacementPair[1] == '\U':
+                elif replacementPair[1] == r'\U':
                     uNewEntityNameUser = uEntityNameUser.upper()
                     triggeredUserRegexToAppend = "entity name should be uppercase"
                 elif replacementPair[1] == '\A':

--- a/scripts/workspace_compose.py
+++ b/scripts/workspace_compose.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import os, json, sys, argparse, codecs
 from cfgCommons import Cfg

--- a/scripts/workspace_deploy.py
+++ b/scripts/workspace_deploy.py
@@ -12,11 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import os, json, sys, argparse, requests, configparser
 from wawCommons import printf, eprintf
 from cfgCommons import Cfg
 import datetime
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 if __name__ == '__main__':
     print('STARTING: ' + os.path.basename(__file__) + '\n')

--- a/scripts/workspace_test.py
+++ b/scripts/workspace_test.py
@@ -31,6 +31,7 @@ if __name__ == '__main__':
     args = parser.parse_args(sys.argv[1:])
 
     VERBOSE = args.verbose
+    receivedOutputJson = []
 
     # load config file
     conversationSection = 'conversation'

--- a/tests/test_xls2xml/test_XMLHandler.py
+++ b/tests/test_xls2xml/test_XMLHandler.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import print_function
 import unittest
 from scripts.XMLHandler import XMLHandler
 import scripts.DialogData as Dialog
@@ -134,8 +135,8 @@ class XMLHandlerTest(unittest.TestCase):
         actual = self._handler.printXml(xmlDocument, False)
         expected = (u'<nodes><node name="HELP_2"><condition>#HELP_2</condition><output><textValues>'
                     u'<values>Sorry, cannot help you.</values></textValues></output></node></nodes>')
-        print actual
-        print expected
+        print(actual)
+        print(expected)
         self.assertEquals(actual, expected)
 
 


### PR DESCRIPTION
Fixes #149

Just like the PR #148 but without the `from __future__ import absolute_import` bit which might cause issues.
