### PR TITLE
from __future__ import absolute_import

### DIFF
--- a/scripts/DialogData.py
+++ b/scripts/DialogData.py
@@ -12,8 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-from IntentData import IntentData
+from scripts.IntentData import IntentData
 
 X_PLACEHOLDER = '<x>'
 

--- a/scripts/IntentData.py
+++ b/scripts/IntentData.py
@@ -12,10 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
 import re
-from wawCommons import eprintf
 from collections import OrderedDict
+
+from wawCommons import eprintf
+
 
 class IntentData(object):
     """ Represents a data structure containing all necessary information for a single Dialog intent. """

--- a/scripts/IntentData.py
+++ b/scripts/IntentData.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import re
 from collections import OrderedDict
 
-from wawCommons import eprintf
+from scripts.wawCommons import eprintf
 
 
 class IntentData(object):

--- a/scripts/XLSXHandler.py
+++ b/scripts/XLSXHandler.py
@@ -12,14 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import os, re
+from __future__ import absolute_import
+
+import os
+import re
+from xml.sax.saxutils import escape
+from zipfile import BadZipfile
+
 import unidecode
 from openpyxl import load_workbook
-from wawCommons import printf, eprintf, toIntentName
-from zipfile import BadZipfile
-from xml.sax.saxutils import escape
-import DialogData as Dialog
-from DialogData import DialogData
+from scripts import DialogData as Dialog
+from scripts.DialogData import DialogData
+from scripts.wawCommons import eprintf, printf, toIntentName
 
 NAME_POLICY = 'soft'
 

--- a/scripts/XMLHandler.py
+++ b/scripts/XMLHandler.py
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
 import lxml.etree as XML
-from wawCommons import eprintf, toIntentName
+from scripts.wawCommons import eprintf, toIntentName
 
 # Watson Assistant limits number of options currently to 5, we cut the end of the list of options if it is longer
 MAX_OPTIONS = 50

--- a/scripts/cfgCommons.py
+++ b/scripts/cfgCommons.py
@@ -12,10 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import logging, configparser, sys
-from wawCommons import printf, eprintf
+import configparser
+import logging
+import sys
+
+from scripts.wawCommons import eprintf
+
 
 class Cfg:
 

--- a/scripts/clean_generated.py
+++ b/scripts/clean_generated.py
@@ -12,13 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import sys, argparse, os
-import wawCommons
-from cfgCommons import Cfg
-from wawCommons import printf, eprintf
+import argparse
+import os
 import shutil
+import sys
+
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import printf
 
 if __name__ == '__main__':
     printf('\nSTARTING: ' + os.path.basename(__file__) + '\n')

--- a/scripts/dialog_code2text.py
+++ b/scripts/dialog_code2text.py
@@ -12,10 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json,sys,argparse, re
+import argparse
+import json
+import re
+import sys
+
 import lxml.etree as LET
-from wawCommons import printf, eprintf, toCode
+from scripts.wawCommons import eprintf, printf, toCode
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Replaces codes in text tags with sentences specified in the resource file.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/dialog_json2xml.py
+++ b/scripts/dialog_json2xml.py
@@ -12,11 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import json, sys, argparse, os
+import argparse
+import json
+import os
+import sys
+
 import lxml.etree as LET
-from wawCommons import printf, eprintf
+from scripts.wawCommons import eprintf, printf
 
 try:
     basestring            # Python 2

--- a/scripts/dialog_text2code.py
+++ b/scripts/dialog_text2code.py
@@ -12,10 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json,sys,argparse
+import argparse
+import json
+import sys
+
 import lxml.etree as LET
-from wawCommons import printf, eprintf, toCode
+from scripts.wawCommons import eprintf, printf, toCode
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Replaces sentences in text tags with codes and creates resource file with translations from codes to sentences.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/dialog_xls2xml.py
+++ b/scripts/dialog_xls2xml.py
@@ -12,16 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
+import argparse
+import codecs
+import os
 # coding: utf-8
-import sys, argparse, os, codecs
-from cfgCommons import Cfg
-from wawCommons import printf
-from XLSXHandler import XLSXHandler
-from XMLHandler import XMLHandler
+import sys
 
-from wawCommons import printf, eprintf
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import eprintf, printf
+from scripts.XLSXHandler import XLSXHandler
+from scripts.XMLHandler import XMLHandler
+
 
 def saveDialogDataToFileSystem(dialogData, handler, config):
     if hasattr(config, 'common_generated_dialogs') and not os.path.exists(getattr(config, 'common_generated_dialogs')):
@@ -105,4 +108,3 @@ if __name__ == '__main__':
     saveDialogDataToFileSystem(xlsxHandler.getDialogData(), XMLHandler(), config)
 
     printf('\nFINISHING: ' + os.path.basename(__file__) + '\n')
-

--- a/scripts/dialog_xml2json.py
+++ b/scripts/dialog_xml2json.py
@@ -12,16 +12,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import json,sys,argparse,os,re,csv,io,copy
-import lxml.etree as LET
-from xml.sax.saxutils import unescape
-from cfgCommons import Cfg
-from wawCommons import printf, eprintf
-import time
+import argparse
+import copy
 import datetime
 import io
+import json
+import os
+import re
+import sys
+from xml.sax.saxutils import unescape
+
+import lxml.etree as LET
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import eprintf, printf
 
 try:
     unicode        # Python 2

--- a/scripts/entities_csv2json.py
+++ b/scripts/entities_csv2json.py
@@ -12,12 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import json,sys,argparse,os
+import argparse
 import io
-from cfgCommons import Cfg
-from wawCommons import printf, eprintf, toEntityName, getFilesAtPath
+import json
+import os
+import sys
+
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import getFilesAtPath, printf, toEntityName
+
 
 if __name__ == '__main__':
     printf('\nSTARTING: ' + os.path.basename(__file__) + '\n')
@@ -32,10 +37,9 @@ if __name__ == '__main__':
     parser.add_argument('-v','--common_verbose', required=False, help='verbosity', action='store_true')
     parser.add_argument('-s', '--common_soft', required=False, help='soft name policy - change intents and entities names without error.', action='store_true', default="")
     args = parser.parse_args(sys.argv[1:])
-    config = Cfg(args);
+    config = Cfg(args)
     VERBOSE = hasattr(config, 'common_verbose')
-    if args.common_soft: NAME_POLICY = 'soft'
-    else: NAME_POLICY = 'hard'
+    NAME_POLICY = 'soft' if args.common_soft else 'hard'
 
     if not hasattr(config, 'common_entities'):
         print('entities parameter is not defined.')

--- a/scripts/entities_csv2nlu.py
+++ b/scripts/entities_csv2nlu.py
@@ -12,10 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import sys, argparse, os, re
+import argparse
+import os
+import re
+import sys
 from collections import defaultdict
-from wawCommons import printf, eprintf, toIntentName, toEntityName
+
+from scripts.wawCommons import eprintf, printf, toEntityName, toIntentName
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='convert NLU tsv files into domain-entity and intent-entity mappings.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/entities_json2csv.py
+++ b/scripts/entities_json2csv.py
@@ -12,9 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json, sys, argparse, os
-from wawCommons import printf, eprintf, toEntityName
+import argparse
+import json
+import os
+import sys
+
+from scripts.wawCommons import eprintf, printf, toEntityName
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Decompose Bluemix conversation service entities in .json format to entity files in .csv format', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/evaluate_tests.py
+++ b/scripts/evaluate_tests.py
@@ -12,10 +12,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json, sys, argparse, requests, os, time, datetime, re
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+import time
+
+import requests
+
 import lxml.etree as LET
-from wawCommons import printf, eprintf
+from scripts.wawCommons import eprintf, printf
 
 try:
     basestring            # Python 2

--- a/scripts/functions_deploy.py
+++ b/scripts/functions_deploy.py
@@ -12,13 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import os, json, sys, argparse, requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from cfgCommons import Cfg
-from wawCommons import printf, eprintf, getFilesAtPath
+import argparse
+import json
+import os
+import sys
+
+import requests
 import urllib3
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import eprintf, getFilesAtPath, printf
 
 if __name__ == '__main__':
     printf('\nSTARTING: '+ os.path.basename(__file__) + '\n')

--- a/scripts/intents_csv2json.py
+++ b/scripts/intents_csv2json.py
@@ -12,11 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import json, sys, argparse, os, glob, codecs
-from wawCommons import printf, eprintf, getFilesAtPath, toIntentName
-from cfgCommons import Cfg
+import argparse
+import codecs
+import glob
+import json
+import os
+import sys
+
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import eprintf, getFilesAtPath, printf, toIntentName
 
 if __name__ == '__main__':
     printf('\nSTARTING: ' + os.path.basename(__file__) + '\n')

--- a/scripts/intents_csv2nlu.py
+++ b/scripts/intents_csv2nlu.py
@@ -12,9 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import sys, argparse, os, re
-from wawCommons import printf, eprintf, toIntentName, toEntityName
+import argparse
+import os
+import re
+import sys
+
+from scripts.wawCommons import eprintf, printf, toEntityName, toIntentName
+
 
 def getEntities(entityDir, NAME_POLICY):
     """Retrieves entity value to entity name mapping from the directory with entity lists"""

--- a/scripts/intents_json2csv.py
+++ b/scripts/intents_json2csv.py
@@ -12,9 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json, sys, argparse, os
-from wawCommons import printf, eprintf, toIntentName
+import argparse
+import json
+import os
+import sys
+
+from scripts.wawCommons import eprintf, printf, toIntentName
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Decompose Bluemix conversation service intents in .json format to intent files in .csv format', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/update_all.py
+++ b/scripts/update_all.py
@@ -12,11 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import os, sys, logging
-import subprocess, argparse
-from wawCommons import printf, eprintf
+import argparse
+import logging
+import os
+import subprocess
+import sys
+
+from scripts.wawCommons import eprintf, printf
 
 if __name__ == '__main__':
     printf('\nSTARTING: ' + os.path.basename(__file__) + '\n')

--- a/scripts/wawCommons.py
+++ b/scripts/wawCommons.py
@@ -15,9 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys, re, codecs, os
-import unicodedata, unidecode
+import codecs
+import os
+import re
+import sys
+import unicodedata
+
 import lxml.etree as Xml
+import unidecode
 
 restrictionTextNamePolicy = "NAME_POLICY can be only set to either 'soft', 'soft_verbose' or 'hard'"
 

--- a/scripts/workspace_compose.py
+++ b/scripts/workspace_compose.py
@@ -12,12 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import os, json, sys, argparse, codecs
+import argparse
+import codecs
 import io
-from cfgCommons import Cfg
-from wawCommons import printf, eprintf
+import json
+import os
+import sys
+
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import printf
+
 
 if __name__ == '__main__':
     printf('\nSTARTING: ' + os.path.basename(__file__) + '\n')

--- a/scripts/workspace_decompose.py
+++ b/scripts/workspace_decompose.py
@@ -12,9 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json, sys, argparse
-from wawCommons import printf, eprintf
+import argparse
+import json
+import sys
+
+from scripts.wawCommons import eprintf, printf
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Decompose Bluemix conversation service workspace in .json format to intents json, entities json and dialog json', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/workspace_delete.py
+++ b/scripts/workspace_delete.py
@@ -12,9 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import sys, argparse, requests, configparser
-from wawCommons import printf, eprintf
+import argparse
+import configparser
+import sys
+
+import requests
+
+from scripts.wawCommons import eprintf, printf
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Deletes Bluemix conversation service workspace and deletes workspace id from config file.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/scripts/workspace_deploy.py
+++ b/scripts/workspace_deploy.py
@@ -12,12 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import os, json, sys, argparse, requests, configparser
-from wawCommons import printf, eprintf
-from cfgCommons import Cfg
+import argparse
+import configparser
 import datetime
+import json
+import os
+import sys
+
+import requests
+
+from scripts.cfgCommons import Cfg
+from scripts.wawCommons import eprintf, printf
 
 try:
     unicode        # Python 2

--- a/scripts/workspace_test.py
+++ b/scripts/workspace_test.py
@@ -12,9 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
 
-import json, sys, time, argparse, requests, configparser
-from wawCommons import printf, eprintf
+import argparse
+import configparser
+import json
+import sys
+import time
+
+import requests
+
+from scripts.wawCommons import eprintf, printf
 
 CHECK_MESSAGES_TIME_MAX = 5 # in seconds
 CHECK_WORKSPACE_TIME_DELAY = 1 # in seconds


### PR DESCRIPTION
Modify the __import__ statements to be compatible with Python 3's requirement for absolute imports.
* Also ran [__isort__](http://isort.readthedocs.io) on the modified files to standardized the order of imports to improve readability.