### PR TITLE
fix for script not exporting pattern entities as patterns but synonyms

### DIFF
--- a/scripts/entities_csv2json.py
+++ b/scripts/entities_csv2json.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
                         representativeValue = rawSynonyms[0]
                         synonyms = sorted(list(set(rawSynonyms[1:])))
                         valueJSON = {}
-                        if representativeValue[0] is '~':
+                        if representativeValue[0] in '~':
                             # all patterns are represented by the first value without first char (~)
                             valueJSON['type'] = 'patterns'
                             valueJSON['value'] = representativeValue[1:]


### PR DESCRIPTION
The "if" statement did not catch the "~", resulted in exporting pattern entities as regular ones.