### PR TITLE
urllib.quote --> urllib.parse.quote for Python 3

### DIFF
--- a/ci/unit_tests/functions_deploy/main_test.py
+++ b/ci/unit_tests/functions_deploy/main_test.py
@@ -155,7 +155,7 @@ class TestMain(BaseTestCaseCapture):
         self.packageCreated = True
 
         # call function and check if sub-function from non-main file was called
-        functionCallUrl = actionsUrl + self.package + '/testFunc?blocking=true&result=true'
+        functionCallUrl = self.actionsUrl + self.package + '/testFunc?blocking=true&result=true'
 
         functionResp = requests.post(functionCallUrl, auth=(self.username, self.password),
                                      headers={'Content-Type': 'application/json', 'accept': 'application/json'},

--- a/ci/unit_tests/functions_deploy/main_test.py
+++ b/ci/unit_tests/functions_deploy/main_test.py
@@ -38,7 +38,7 @@ class TestMain(BaseTestCaseCapture):
                                                'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
         cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
         cls.urlNamespace = quote(cls.namespace)
-        cls.actionsUrl = self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/'
+        cls.actionsUrl = cls.cloudFunctionsUrl + '/' + cls.urlNamespace + '/actions/'
 
     def callfunc(self, *args, **kwargs):
         functions_deploy.main(*args, **kwargs)

--- a/ci/unit_tests/functions_deploy/main_test.py
+++ b/ci/unit_tests/functions_deploy/main_test.py
@@ -20,7 +20,7 @@ from ...test_utils import BaseTestCaseCapture
 
 try:
     from urllib.parse import quote
-except:
+except ImportError:
     from urllib import quote
 
 
@@ -38,13 +38,13 @@ class TestMain(BaseTestCaseCapture):
                                                'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
         cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
         cls.urlNamespace = quote(cls.namespace)
+        cls.actionsUrl = self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/'
 
     def callfunc(self, *args, **kwargs):
         functions_deploy.main(*args, **kwargs)
 
     def _getFunctionsInPackage(self, package):
-        functionListUrl = self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/?limit=0&skip=0'
-
+        functionListUrl = self.actionsUrl + '?limit=0&skip=0'
         functionListResp = requests.get(functionListUrl, auth=(self.username, self.password),
                                         headers={'accept': 'application/json'})
 
@@ -69,8 +69,7 @@ class TestMain(BaseTestCaseCapture):
             # get all functions in package and remove them
             functionNames = self._getFunctionsInPackage(self.package)
             for functionName in functionNames:
-                functionDelUrl =  self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/' + self.package + \
-                    '/' + functionName
+                functionDelUrl =  self.actionsUrl + self.package + '/' + functionName
 
                 functionDelResp = requests.delete(functionDelUrl, auth=(self.username, self.password))
                 assert functionDelResp.status_code == 200
@@ -104,8 +103,7 @@ class TestMain(BaseTestCaseCapture):
 
         # try to call particular functions
         for functionName in functionNames:
-            functionCallUrl = self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/' + self.package + \
-                '/' + functionName + '?blocking=true&result=true'
+            functionCallUrl = self.actionsUrl + self.package + '/' + functionName + '?blocking=true&result=true'
 
             functionResp = requests.post(functionCallUrl, auth=(self.username, self.password),
                                          headers={'Content-Type': 'application/json', 'accept': 'application/json'},
@@ -127,8 +125,7 @@ class TestMain(BaseTestCaseCapture):
             self.t_noException([params])
             self.packageCreated = True
 
-            functionCallUrl = self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/' + self.package + \
-                '/getPythonMajorVersion?blocking=true&result=true'
+            functionCallUrl = self.actionsUrl + self.package + '/getPythonMajorVersion?blocking=true&result=true'
 
             functionResp = requests.post(functionCallUrl, auth=(self.username, self.password),
                                          headers={'Content-Type': 'application/json', 'accept': 'application/json'},
@@ -158,8 +155,7 @@ class TestMain(BaseTestCaseCapture):
         self.packageCreated = True
 
         # call function and check if sub-function from non-main file was called
-        functionCallUrl = self.cloudFunctionsUrl + '/' + self.urlNamespace + '/actions/' + self.package + \
-            '/testFunc?blocking=true&result=true'
+        functionCallUrl = actionsUrl + self.package + '/testFunc?blocking=true&result=true'
 
         functionResp = requests.post(functionCallUrl, auth=(self.username, self.password),
                                      headers={'Content-Type': 'application/json', 'accept': 'application/json'},

--- a/ci/unit_tests/functions_deploy/main_test.py
+++ b/ci/unit_tests/functions_deploy/main_test.py
@@ -13,10 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import json, os, requests, shutil, unittest, urllib, uuid, zipfile
+import json, os, requests, shutil, unittest, uuid, zipfile
 
 import functions_deploy
 from ...test_utils import BaseTestCaseCapture
+
+try:
+    from urllib.parse import quote
+except:
+    from urllib import quote
+
 
 class TestMain(BaseTestCaseCapture):
 
@@ -31,7 +37,7 @@ class TestMain(BaseTestCaseCapture):
         cls.cloudFunctionsUrl = os.environ.get('CLOUD_FUNCTIONS_URL',
                                                'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
         cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
-        cls.urlNamespace = urllib.quote(cls.namespace)
+        cls.urlNamespace = quote(cls.namespace)
 
     def callfunc(self, *args, **kwargs):
         functions_deploy.main(*args, **kwargs)


### PR DESCRIPTION
```
_________ ERROR at setup of TestMain.test_functionsUploadFromDirectory _________
cls = <class 'ci.unit_tests.functions_deploy.main_test.TestMain'>
    def setup_class(cls):
        BaseTestCaseCapture.checkEnvironmentVariables(['CLOUD_FUNCTIONS_USERNAME', 'CLOUD_FUNCTIONS_PASSWORD',
                                                       'CLOUD_FUNCTIONS_NAMESPACE'])
        cls.username = os.environ['CLOUD_FUNCTIONS_USERNAME']
        cls.password = os.environ['CLOUD_FUNCTIONS_PASSWORD']
        cls.cloudFunctionsUrl = os.environ.get('CLOUD_FUNCTIONS_URL',
                                               'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
        cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
>       cls.urlNamespace = urllib.quote(cls.namespace)
E       AttributeError: module 'urllib' has no attribute 'quote'
ci/unit_tests/functions_deploy/main_test.py:34: AttributeError
____________ ERROR at setup of TestMain.test_pythonVersionFunctions ____________
cls = <class 'ci.unit_tests.functions_deploy.main_test.TestMain'>
    def setup_class(cls):
        BaseTestCaseCapture.checkEnvironmentVariables(['CLOUD_FUNCTIONS_USERNAME', 'CLOUD_FUNCTIONS_PASSWORD',
                                                       'CLOUD_FUNCTIONS_NAMESPACE'])
        cls.username = os.environ['CLOUD_FUNCTIONS_USERNAME']
        cls.password = os.environ['CLOUD_FUNCTIONS_PASSWORD']
        cls.cloudFunctionsUrl = os.environ.get('CLOUD_FUNCTIONS_URL',
                                               'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
        cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
>       cls.urlNamespace = urllib.quote(cls.namespace)
E       AttributeError: module 'urllib' has no attribute 'quote'
ci/unit_tests/functions_deploy/main_test.py:34: AttributeError
________________ ERROR at setup of TestMain.test_functionsInZip ________________
cls = <class 'ci.unit_tests.functions_deploy.main_test.TestMain'>
    def setup_class(cls):
        BaseTestCaseCapture.checkEnvironmentVariables(['CLOUD_FUNCTIONS_USERNAME', 'CLOUD_FUNCTIONS_PASSWORD',
                                                       'CLOUD_FUNCTIONS_NAMESPACE'])
        cls.username = os.environ['CLOUD_FUNCTIONS_USERNAME']
        cls.password = os.environ['CLOUD_FUNCTIONS_PASSWORD']
        cls.cloudFunctionsUrl = os.environ.get('CLOUD_FUNCTIONS_URL',
                                               'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
        cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
>       cls.urlNamespace = urllib.quote(cls.namespace)
E       AttributeError: module 'urllib' has no attribute 'quote'
ci/unit_tests/functions_deploy/main_test.py:34: AttributeError
___________________ ERROR at setup of TestMain.test_badArgs ____________________
cls = <class 'ci.unit_tests.functions_deploy.main_test.TestMain'>
    def setup_class(cls):
        BaseTestCaseCapture.checkEnvironmentVariables(['CLOUD_FUNCTIONS_USERNAME', 'CLOUD_FUNCTIONS_PASSWORD',
                                                       'CLOUD_FUNCTIONS_NAMESPACE'])
        cls.username = os.environ['CLOUD_FUNCTIONS_USERNAME']
        cls.password = os.environ['CLOUD_FUNCTIONS_PASSWORD']
        cls.cloudFunctionsUrl = os.environ.get('CLOUD_FUNCTIONS_URL',
                                               'https://us-south.functions.cloud.ibm.com/api/v1/namespaces')
        cls.namespace = os.environ['CLOUD_FUNCTIONS_NAMESPACE']
>       cls.urlNamespace = urllib.quote(cls.namespace)
E       AttributeError: module 'urllib' has no attribute 'quote'
ci/unit_tests/functions_deploy/main_test.py:34: AttributeError
```