### PR TITLE
 AttributeError: 'str' object has no attribute 'decode'

### DIFF
--- a/scripts/wawCommons.py
+++ b/scripts/wawCommons.py
@@ -29,7 +29,7 @@ def toCode(NAME_POLICY, code):
     restrictionTextCode = "The code can only contain uppercase letters (in Unicode), numbers, underscores, and hyphens."
     code = code.strip()
     newCode = re.sub(' ', '_', code, re.UNICODE).upper()
-    if isinstance(newCode, str):
+    if isinstance(newCode, bytes):
         newIntentSubname = newCode.decode('utf-8')
         # use unidecode.unidecode ?
         newCode = unicodedata.normalize('NFKD', newCode.decode('utf-8')).encode('ASCII', 'ignore')  # remove accents
@@ -68,7 +68,7 @@ def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
     for intentSubname in intentSubnames:
         if not intentSubname: continue
         intentSubname = intentSubname.strip()
-        uIntentSubname = intentSubname.decode('utf-8') if isinstance(intentSubname, str) else intentSubname
+        uIntentSubname = intentSubname.decode('utf-8') if isinstance(intentSubname, bytes) else intentSubname
         # apply WA restrictions (https://console.bluemix.net/docs/services/conversation/intents.html#defining-intents)
         uIntentSubnameWA = re.sub(' ;', '_', uIntentSubname, re.UNICODE) # replace space and ; by underscore
         uIntentSubnameWA = re.sub(u'[^\wÀ-ÖØ-öø-ÿĀ-ž-\.]', '', uIntentSubnameWA, re.UNICODE) # remove everything that is not unicode letter, hyphen or period
@@ -150,7 +150,7 @@ def toEntityName(NAME_POLICY, userReplacements, entityName):
     global restrictionTextNamePolicy
     restrictionTextEntityName = []
     entityName = entityName.strip()
-    uEntityName = entityName.decode('utf-8') if isinstance(entityName, str) else entityName
+    uEntityName = entityName.decode('utf-8') if isinstance(entityName, bytes) else entityName
     # apply WA restrictions (https://console.bluemix.net/docs/services/conversation/entities.html#defining-entities)
     uEntityNameWA = re.sub(' ', '_', uEntityName, re.UNICODE) # replace spaces with underscores
     uEntityNameWA = re.sub(u'[^\wÀ-ÖØ-öø-ÿĀ-ž-]', '', uEntityNameWA, re.UNICODE) # remove everything that is not unicode letter or hyphen
@@ -248,7 +248,7 @@ def absoluteFilePaths(directory, patterns=['*']):
         for f in filenames:
             if _fileMatchesPatterns(f, patterns):
                 yield os.path.abspath(os.path.join(dirpath, f))
-           
+
 def _fileMatchesPatterns(filename, patterns):
     """Helper function which checks if file matches one the patterns."""
     for pattern in patterns:

--- a/scripts/wawCommons.py
+++ b/scripts/wawCommons.py
@@ -71,7 +71,7 @@ def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
         uIntentSubname = intentSubname.decode('utf-8') if isinstance(intentSubname, bytes) else intentSubname
         # apply WA restrictions (https://console.bluemix.net/docs/services/conversation/intents.html#defining-intents)
         uIntentSubnameWA = re.sub(' ;', '_', uIntentSubname, re.UNICODE) # replace space and ; by underscore
-        uIntentSubnameWA = re.sub(u'[^\\wÀ-ÖØ-öø-ÿĀ-ž-\.]', '', uIntentSubnameWA, re.UNICODE) # remove everything that is not unicode letter, hyphen or period
+        uIntentSubnameWA = re.sub(u'[^\\wÀ-ÖØ-öø-ÿĀ-ž-\\.]', '', uIntentSubnameWA, re.UNICODE) # remove everything that is not unicode letter, hyphen or period
         if uIntentSubnameWA != uIntentSubname: # WA restriction triggered
             restrictionTextIntentName.append("The intent name can only contain letters (in Unicode), numbers, underscores, hyphens, and periods.")
         # apply user-defined restrictions

--- a/scripts/wawCommons.py
+++ b/scripts/wawCommons.py
@@ -34,7 +34,7 @@ def toCode(NAME_POLICY, code):
         # use unidecode.unidecode ?
         newCode = unicodedata.normalize('NFKD', newCode.decode('utf-8')).encode('ASCII', 'ignore')  # remove accents
     # remove everything that is not unicode letter or hyphen
-    newCode = re.sub('[^\w-]', '', newCode, re.UNICODE)
+    newCode = re.sub('[^\\w-]', '', newCode, re.UNICODE)
     if newCode != code:
         if NAME_POLICY == 'soft_verbose':
             logger.warning("Illegal value of the code: '%s'- %s", code, restrictionTextCode)
@@ -52,7 +52,7 @@ def normalizeIntentName(intentName):
     return re.sub('[-_]', '', intentName).upper()
 
 def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
-    """Concatenates intent names with underscores,
+    r"""Concatenates intent names with underscores,
     checks if the intent name satisfies all restrictions given by WA and user.
     WA replacements:
      - replace spaces and semicolons with uderscores
@@ -71,7 +71,7 @@ def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
         uIntentSubname = intentSubname.decode('utf-8') if isinstance(intentSubname, bytes) else intentSubname
         # apply WA restrictions (https://console.bluemix.net/docs/services/conversation/intents.html#defining-intents)
         uIntentSubnameWA = re.sub(' ;', '_', uIntentSubname, re.UNICODE) # replace space and ; by underscore
-        uIntentSubnameWA = re.sub(u'[^\wÀ-ÖØ-öø-ÿĀ-ž-\.]', '', uIntentSubnameWA, re.UNICODE) # remove everything that is not unicode letter, hyphen or period
+        uIntentSubnameWA = re.sub(u'[^\\wÀ-ÖØ-öø-ÿĀ-ž-\.]', '', uIntentSubnameWA, re.UNICODE) # remove everything that is not unicode letter, hyphen or period
         if uIntentSubnameWA != uIntentSubname: # WA restriction triggered
             restrictionTextIntentName.append("The intent name can only contain letters (in Unicode), numbers, underscores, hyphens, and periods.")
         # apply user-defined restrictions
@@ -139,7 +139,7 @@ def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
     return uNewIntentName.encode('utf-8')
 
 def toEntityName(NAME_POLICY, userReplacements, entityName):
-    """Checks if the entity name satisfies all restrictions given by WA and user.
+    r"""Checks if the entity name satisfies all restrictions given by WA and user.
     WA replacements:
      - replace spaces with uderscores
      - remove everything that is not unicode letter or hyphen
@@ -153,7 +153,7 @@ def toEntityName(NAME_POLICY, userReplacements, entityName):
     uEntityName = entityName.decode('utf-8') if isinstance(entityName, bytes) else entityName
     # apply WA restrictions (https://console.bluemix.net/docs/services/conversation/entities.html#defining-entities)
     uEntityNameWA = re.sub(' ', '_', uEntityName, re.UNICODE) # replace spaces with underscores
-    uEntityNameWA = re.sub(u'[^\wÀ-ÖØ-öø-ÿĀ-ž-]', '', uEntityNameWA, re.UNICODE) # remove everything that is not unicode letter or hyphen
+    uEntityNameWA = re.sub(u'[^\\wÀ-ÖØ-öø-ÿĀ-ž-]', '', uEntityNameWA, re.UNICODE) # remove everything that is not unicode letter or hyphen
     if uEntityNameWA != uEntityName: # WA restriction triggered
         restrictionTextEntityName.append("The entity name can only contain letters (in Unicode), numbers, underscores, and hyphens.")
     # apply user-defined restrictions


### PR DESCRIPTION
In Python 2 __str__ == __bytes__ but in Python 3 __str__ is Unicode and only __bytes__ have a __.decode()__ method.
```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
NAME_POLICY = 'soft', userReplacements = None, intentSubnames = ('E_EN_master',)
restrictionTextIntentName = [], uNewIntentName = ''
intentSubname = 'E_EN_master'
    def toIntentName(NAME_POLICY, userReplacements, *intentSubnames):
        """Concatenates intent names with underscores,
        checks if the intent name satisfies all restrictions given by WA and user.
        WA replacements:
         - replace spaces and semicolons with uderscores
         - remove everything that is not unicode letter, hyphen or period
        User defined replacements:
         e.g. userReplacements = [['$special', '\L'], ['-', '_']] which change all letters to lowercase and replace all hyphens for underscores
        If the name does not satisfy all restrictions, this function will return corrected name and print warning (NAME_POLICY soft_verbose)
        or it will end up with an error (NAME_POLICY hard)"""
        """Removes all unexpected characters from the intent names, normalize them to upper case and concatenate them with the underscores"""
        global restrictionTextNamePolicy
        restrictionTextIntentName = []
        uNewIntentName = u""
        for intentSubname in intentSubnames:
            if not intentSubname: continue
            intentSubname = intentSubname.strip()
>           uIntentSubname = intentSubname.decode('utf-8') if isinstance(intentSubname, str) else intentSubname
E           AttributeError: 'str' object has no attribute 'decode'
scripts/wawCommons.py:71: AttributeError

=============================== warnings summary ===============================
scripts/wawCommons.py:37
  /home/travis/build/IBM/watson-assistant-workbench/scripts/wawCommons.py:37: DeprecationWarning: invalid escape sequence \w
    newCode = re.sub('[^\w-]', '', newCode, re.UNICODE)
scripts/wawCommons.py:63
  /home/travis/build/IBM/watson-assistant-workbench/scripts/wawCommons.py:63: DeprecationWarning: invalid escape sequence \L
    or it will end up with an error (NAME_POLICY hard)"""
scripts/wawCommons.py:74
  /home/travis/build/IBM/watson-assistant-workbench/scripts/wawCommons.py:74: DeprecationWarning: invalid escape sequence \w
    uIntentSubnameWA = re.sub(u'[^\wÀ-ÖØ-öø-ÿĀ-ž-\.]', '', uIntentSubnameWA, re.UNICODE) # remove everything that is not unicode letter, hyphen or period
scripts/wawCommons.py:149
  /home/travis/build/IBM/watson-assistant-workbench/scripts/wawCommons.py:149: DeprecationWarning: invalid escape sequence \L
    or it will end up with an error (NAME_POLICY hard)"""
scripts/wawCommons.py:156
  /home/travis/build/IBM/watson-assistant-workbench/scripts/wawCommons.py:156: DeprecationWarning: invalid escape sequence \w
    uEntityNameWA = re.sub(u'[^\wÀ-ÖØ-öø-ÿĀ-ž-]', '', uEntityNameWA, re.UNICODE) # remove everything that is not unicode letter or hyphen
```