### PR TITLE
Fix invalid escape sequences for Python 3

### DIFF
--- a/ci/app_tests/generateAndTestWorkspace_test.py
+++ b/ci/app_tests/generateAndTestWorkspace_test.py
@@ -98,10 +98,10 @@ class TestGenerateAndTestWorkspace(BaseTestCaseCapture):
         with open(xmlCondXTestPath, 'r') as file:
             fileContent = file.read()
             # it is necessary to have 'Z.*vada' because original word to be matched, 'Z<A-ACUTE>vada', is represented like 'Z\xc3\xa1vada', same thing for others patterns
-            assert re.compile('#CO_JE.*@PREDMET:\(Z.*vada\)').search(fileContent)
-            assert re.compile('#CO_JE.*@PREDMET:\(V.*stra.*n.* stav\)').search(fileContent)
-            assert re.compile('#CO_JE.*@PREDMET:\(Vyrovn.*vac.* trh\)').search(fileContent)
-            assert re.compile('#CO_JE.*@PREDMET:\(Buttons do not belong here\)').search(fileContent)
+            assert re.compile('#CO_JE.*@PREDMET:\\(Z.*vada\\)').search(fileContent)
+            assert re.compile('#CO_JE.*@PREDMET:\\(V.*stra.*n.* stav\\)').search(fileContent)
+            assert re.compile('#CO_JE.*@PREDMET:\\(Vyrovn.*vac.* trh\\)').search(fileContent)
+            assert re.compile('#CO_JE.*@PREDMET:\\(Buttons do not belong here\\)').search(fileContent)
 
         # convert dialog from xml to json
         self.t_fun_noException(dialog_xml2json.main, [['-dm', dialogMainPath, '-of', self.testOutputPath, '-od', jsonDialogFilename, '-s', self.dialogSchemaPath, '-c', configBuildPath, '-v']])

--- a/scripts/DialogData.py
+++ b/scripts/DialogData.py
@@ -168,7 +168,7 @@ class DialogData(object):
             :returns unique intent_name or None if not able to create
         """
         #Normalize the string
-        unique_intent_name = toIntentName( self._NAME_POLICY, [['$special', '\A']], intent_name).decode('utf-8')
+        unique_intent_name = toIntentName( self._NAME_POLICY, [['$special', '\\A']], intent_name).decode('utf-8')
         if unique_intent_name not in self._intents:
             return unique_intent_name
         #try to modify by a number
@@ -188,7 +188,7 @@ class DialogData(object):
             :returns unique entity_name or None if not able to create
         """
         #Normalize the string
-        unique_entity_name = toEntityName(self._NAME_POLICY, [['$special', '\A']], entity_name).decode('utf-8')
+        unique_entity_name = toEntityName(self._NAME_POLICY, [['$special', '\\A']], entity_name).decode('utf-8')
         if unique_entity_name not in self._entities:
             return unique_entity_name
         #try to modify by a number
@@ -208,7 +208,7 @@ class DialogData(object):
             :return: unique node_name or None if not able to create
         """
         # Normalize the string
-        unique_node_name = toIntentName(self._NAME_POLICY, [['$special', '\A']], node_name).decode('utf-8').upper()
+        unique_node_name = toIntentName(self._NAME_POLICY, [['$special', '\\A']], node_name).decode('utf-8').upper()
         if unique_node_name not in self._nodes:
             return unique_node_name
         # try to modify by a number

--- a/scripts/XLSXHandler.py
+++ b/scripts/XLSXHandler.py
@@ -256,7 +256,7 @@ class XLSXHandler(object):
         if len(block) > 1 and block[1][0]:
             logger.error('Format error. condititional block without header shold have just one condition: %s', block[0])
             exit()
-        node_condition = re.sub(u"#\$ ", u"", block[0][0])
+        node_condition = re.sub(u"#\\$ ", u"", block[0][0])
         node_name = self._dialogData.createUniqueNodeName(block[0][0])  # derive node name from explicit condition and make it unique
         node_condition = node_condition
         nodeData = self._dialogData.createNode(node_name, domain)  # create space for new node, remembers node_name

--- a/scripts/dialog_xml2json.py
+++ b/scripts/dialog_xml2json.py
@@ -297,7 +297,7 @@ def validateNodeName(node):
     global names
     name = node.find('name').text
     # check characters (Node names can only contain letters, numbers, hyphens and underscores)
-    pattern = re.compile("[\w-]+", re.UNICODE)
+    pattern = re.compile("[\\w-]+", re.UNICODE)
     if not pattern.match(name):
         logger.error("Illegal name of the node: '%s' - Node names can only contain letters, numbers, hyphens and underscores.", name)
         exit(1)

--- a/scripts/entities_csv2json.py
+++ b/scripts/entities_csv2json.py
@@ -31,7 +31,7 @@ def main(argv):
     parser.add_argument('-ge', '--common_generated_entities', help='directory with generated entity csv files to be processed (all of them will be included in output json)', action='append')
     parser.add_argument('-od', '--common_outputs_directory', required=False, help='directory where the otputs will be stored (outputs is default)')
     parser.add_argument('-oe', '--common_outputs_entities', help='file with output json with all the entities')
-    parser.add_argument('-ne', '--common_entities_nameCheck', action='append', nargs=2, help="regex and replacement for entity name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
+    parser.add_argument('-ne', '--common_entities_nameCheck', action='append', nargs=2, help="regex and replacement for entity name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\\L' for lowercase")
     parser.add_argument('-v','--common_verbose', required=False, help='verbosity', action='store_true')
     parser.add_argument('-s', '--common_soft', required=False, help='soft name policy - change intents and entities names without error.', action='store_true', default="")
     args = parser.parse_args(argv)

--- a/scripts/entities_json2csv.py
+++ b/scripts/entities_json2csv.py
@@ -25,7 +25,7 @@ def main(argv):
     parser.add_argument('entities', help='file with entities in .json format')
     parser.add_argument('entitiesDir', help='directory with entities files')
     # optional arguments
-    parser.add_argument('-ne', '--common_entities_nameCheck', action='append', nargs=2, help="regex and replacement for entity name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
+    parser.add_argument('-ne', '--common_entities_nameCheck', action='append', nargs=2, help="regex and replacement for entity name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\\L' for lowercase")
     parser.add_argument('-s', '--soft', required=False, help='soft name policy - change intents and entities names without error.', action='store_true', default="")
     parser.add_argument('-v', '--verbose', required=False, help='verbosity', action='store_true')
     args = parser.parse_args(argv)

--- a/scripts/intents_csv2json.py
+++ b/scripts/intents_csv2json.py
@@ -75,7 +75,7 @@ def main(argv):
     parser.add_argument('-gi', '--common_generated_intents', help='directory with generated intent csv files to be processed (all of them will be included in output json)', action='append')
     parser.add_argument('-od', '--common_outputs_directory', required=False, help='directory where the otputs will be stored (outputs is default)')
     parser.add_argument('-oi', '--common_outputs_intents', help='file with output json with all the intents')
-    parser.add_argument('-ni', '--common_intents_nameCheck', action='append', nargs=2, help="regex and replacement for intent name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
+    parser.add_argument('-ni', '--common_intents_nameCheck', action='append', nargs=2, help="regex and replacement for intent name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\\L' for lowercase")
     parser.add_argument('-s', '--soft', required=False, help='soft name policy - change intents and entities names without error.', action='store_true', default="")
     parser.add_argument('-v','--common_verbose', required=False, help='verbosity', action='store_true')
     args = parser.parse_args(argv)

--- a/scripts/intents_json2csv.py
+++ b/scripts/intents_json2csv.py
@@ -26,7 +26,7 @@ def main(argv):
     parser.add_argument('intents', help='file with intents in .json format')
     parser.add_argument('intentsDir', help='directory with intents files')
     # optional arguments
-    parser.add_argument('-ni', '--common_intents_nameCheck', action='append', nargs=2, help="regex and replacement for intent name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
+    parser.add_argument('-ni', '--common_intents_nameCheck', action='append', nargs=2, help="regex and replacement for intent name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\\L' for lowercase")
     parser.add_argument('-s', '--soft', required=False, help='soft name policy - change intents and entities names without error.', action='store_true', default="")
     parser.add_argument('-v', '--verbose', required=False, help='verbosity', action='store_true')
     args = parser.parse_args(argv)


### PR DESCRIPTION
These warning appear at the end of the PyTest run: https://docs.pytest.org/en/latest/warnings.html
```
scripts/dialog_xml2json.py:300
  /home/travis/build/IBM/watson-assistant-workbench/scripts/dialog_xml2json.py:300: DeprecationWarning: invalid escape sequence \w
    pattern = re.compile("[\w-]+", re.UNICODE)
ci/app_tests/generateAndTestWorkspace_test.py:101
  /home/travis/build/IBM/watson-assistant-workbench/ci/app_tests/generateAndTestWorkspace_test.py:101: DeprecationWarning: invalid escape sequence \(
    assert re.compile('#CO_JE.*@PREDMET:\(Z.*vada\)').search(fileContent)
ci/app_tests/generateAndTestWorkspace_test.py:102
  /home/travis/build/IBM/watson-assistant-workbench/ci/app_tests/generateAndTestWorkspace_test.py:102: DeprecationWarning: invalid escape sequence \(
    assert re.compile('#CO_JE.*@PREDMET:\(V.*stra.*n.* stav\)').search(fileContent)
ci/app_tests/generateAndTestWorkspace_test.py:103
  /home/travis/build/IBM/watson-assistant-workbench/ci/app_tests/generateAndTestWorkspace_test.py:103: DeprecationWarning: invalid escape sequence \(
    assert re.compile('#CO_JE.*@PREDMET:\(Vyrovn.*vac.* trh\)').search(fileContent)
ci/app_tests/generateAndTestWorkspace_test.py:104
  /home/travis/build/IBM/watson-assistant-workbench/ci/app_tests/generateAndTestWorkspace_test.py:104: DeprecationWarning: invalid escape sequence \(
    assert re.compile('#CO_JE.*@PREDMET:\(Buttons do not belong here\)').search(fileContent)
scripts/XLSXHandler.py:259
  /home/travis/build/IBM/watson-assistant-workbench/scripts/XLSXHandler.py:259: DeprecationWarning: invalid escape sequence \$
    node_condition = re.sub(u"#\$ ", u"", block[0][0])
scripts/DialogData.py:171
  /home/travis/build/IBM/watson-assistant-workbench/scripts/DialogData.py:171: DeprecationWarning: invalid escape sequence \A
    unique_intent_name = toIntentName( self._NAME_POLICY, [['$special', '\A']], intent_name).decode('utf-8')
scripts/DialogData.py:191
  /home/travis/build/IBM/watson-assistant-workbench/scripts/DialogData.py:191: DeprecationWarning: invalid escape sequence \A
    unique_entity_name = toEntityName(self._NAME_POLICY, [['$special', '\A']], entity_name).decode('utf-8')
scripts/DialogData.py:211
  /home/travis/build/IBM/watson-assistant-workbench/scripts/DialogData.py:211: DeprecationWarning: invalid escape sequence \A
    unique_node_name = toIntentName(self._NAME_POLICY, [['$special', '\A']], node_name).decode('utf-8').upper()
scripts/entities_csv2json.py:34
  /home/travis/build/IBM/watson-assistant-workbench/scripts/entities_csv2json.py:34: DeprecationWarning: invalid escape sequence \L
    parser.add_argument('-ne', '--common_entities_nameCheck', action='append', nargs=2, help="regex and replacement for entity name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
scripts/entities_json2csv.py:28
  /home/travis/build/IBM/watson-assistant-workbench/scripts/entities_json2csv.py:28: DeprecationWarning: invalid escape sequence \L
    parser.add_argument('-ne', '--common_entities_nameCheck', action='append', nargs=2, help="regex and replacement for entity name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
scripts/intents_csv2json.py:78
  /home/travis/build/IBM/watson-assistant-workbench/scripts/intents_csv2json.py:78: DeprecationWarning: invalid escape sequence \L
    parser.add_argument('-ni', '--common_intents_nameCheck', action='append', nargs=2, help="regex and replacement for intent name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
scripts/intents_json2csv.py:29
  /home/travis/build/IBM/watson-assistant-workbench/scripts/intents_json2csv.py:29: DeprecationWarning: invalid escape sequence \L
    parser.add_argument('-ni', '--common_intents_nameCheck', action='append', nargs=2, help="regex and replacement for intent name check, e.g. '-' '_' for to replace hyphens for underscores or '$special' '\L' for lowercase")
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```