### PR TITLE
I319 set logger config in tests

### DIFF
--- a/ci/pytest.ini
+++ b/ci/pytest.ini
@@ -3,3 +3,4 @@ log_level = DEBUG
 log_format = %(asctime)s %(filename)-27s %(levelname)-8s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 log_print = False
+addopts= --tb=short

--- a/ci/pytest.ini
+++ b/ci/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_level = DEBUG
+log_format = %(asctime)s %(filename)-27s %(levelname)-8s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+log_print = False

--- a/scripts/logging_config.ini
+++ b/scripts/logging_config.ini
@@ -30,7 +30,7 @@ args=()
 
 [formatter_form]
 format=%(asctime)s %(filename)-27s %(levelname)-8s %(message)s
-datefmt=
+datefmt=%Y-%m-%d %H:%M:%S
 
 # To create custom logger for a single script:
 # 1) Create a logger with any name you want, but preferably according to the script name (e.g. 'cfgCommons'), create custom handlers

--- a/scripts/wawCommons.py
+++ b/scripts/wawCommons.py
@@ -422,8 +422,9 @@ def getParametersCombination(config, *args):
 
     return parametersCombinationMap
 
-def setLoggerConfig(level=None, isVerbose=False):
-    fileConfig(os.path.split(os.path.abspath(__file__))[0]+'/logging_config.ini')
+def setLoggerConfig(level=None, isVerbose=False, configPath=None):
+    d = os.path.dirname(os.path.abspath(__file__))
+    fileConfig(configPath or d+'/logging_config.ini')
     l = logging.getLogger()
     logging.Logger.isVerbose = isVerbose
 


### PR DESCRIPTION
I found out that it's not possible to set the logger that pytest uses by just calling `setLoggerConfig()`. Instead, pytest uses its own formatter and configuration. That's why i created the `pytest.ini` file, which gets loaded automatically when pytest is launched. The setings I included are:
- log level and format - so that the pytest logs use the same formatting as the script logs and also prints more messages (DEBUG level), which is useful when trying to figure out why a test failed.
- `log_print=False` - this disables printing of the captured logs. Logging prints to stderr anyway, so this just removes duplicate captures.
- `addopts= --tb=short` - this shortens the traceback messages (until now, the whole file up to the exception was printed, which in my opinion only clutters the logs)