### PR TITLE
Fix None value in node title

### DIFF
--- a/scripts/dialog_json2xml.py
+++ b/scripts/dialog_json2xml.py
@@ -71,7 +71,7 @@ def convertNode(nodeJSON):
     #title
     if 'title' in nodeJSON:
         if nodeJSON['title'] != nodeJSON['dialog_node']: # WA adds title to all uploaded workspaces equal to dialog_name, this is cleanup TODO: remove the conditions when upgrading to new version of WA API
-            nodeXML.attrib['title'] = nodeJSON['title']
+            nodeXML.attrib['title'] = str(nodeJSON['title'])
     #type
     if 'type' in nodeJSON:
         typeNodeXML = LET.Element('type')


### PR DESCRIPTION
When running this script I found an error:
TypeError: Argument must be bytes or unicode, got 'None Type' in convertNode.
In dialog JSON file I had nodes with null value.
Converting nodeJSON['title']  to string solved this problem, on line 74. 
Regarding this issue on stackoverflow: https://stackoverflow.com/questions/44525081/lxml-html-set-error-typeerror-argument-must-be-bytes-or-unicode-got-nonetype
I checked my lxml version, but I have the latest one.