### PR TITLE
Do not break when a dialog node's context has an empty key

### DIFF
--- a/scripts/dialog_json2xml.py
+++ b/scripts/dialog_json2xml.py
@@ -107,6 +107,8 @@ def convertNode(nodeJSON):
              else:
                  contextXML.text = ""
         else:
+            if isinstance(nodeJSON['context'], dict):
+                nodeJSON['context'].pop('', 'unused value to remove ocasional "":"" from context')
             convertAll(nodeXML, nodeJSON, 'context')
     #output
     if 'output' in nodeJSON:


### PR DESCRIPTION
If the dialog contains an empty line in a node's context editor
<img width="744" alt="image" src="https://user-images.githubusercontent.com/460418/66750447-ca659d80-ee8c-11e9-9808-ee4689efe608.png">
the node's context includes a `"":""` dictionary element:
```
"parent": "Welcome",
            "context": {
                "": "",
                "clientProfile": {
...
                    "country": "Canada",
                    "firstName": "Guest"
                }
            },
...
```
and 
`dialog_json2xml.py ` crashes without giving the user any clue about how to fix the problem (`ValueError: Empty tag name`)

